### PR TITLE
Synchronize Item Variants Picture

### DIFF
--- a/src/Apps/W1/Shopify/App/src/GraphQL/Codeunits/ShpfyGQLAddVariantImage.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/GraphQL/Codeunits/ShpfyGQLAddVariantImage.Codeunit.al
@@ -1,0 +1,29 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+
+namespace Microsoft.Integration.Shopify;
+
+codeunit 30405 "Shpfy GQL AddVariantImage" implements "Shpfy IGraphQL"
+{
+    Access = Internal;
+
+    /// <summary>
+    /// GetGraphQL.
+    /// </summary>
+    /// <returns>Return value of type Text.</returns>
+    internal procedure GetGraphQL(): Text
+    begin
+        exit('{"query": "mutation { productVariantsBulkUpdate(productId: \"gid://shopify/Product/{{ProductId}}\" variants: {id: \"gid://shopify/ProductVariant/{{VariantId}}\" mediaSrc: \"{{ResourceUrl}}\"} media: {mediaContentType: IMAGE originalSource: \"{{ResourceUrl}}\"}) { userErrors { code field message } productVariants { media(first: 1){ edges { node { id }}}}}} "}');
+    end;
+
+    /// <summary>
+    /// GetExpectedCost.
+    /// </summary>
+    /// <returns>Return value of type Integer.</returns>
+    internal procedure GetExpectedCost(): Integer
+    begin
+        exit(10);
+    end;
+}

--- a/src/Apps/W1/Shopify/App/src/GraphQL/Codeunits/ShpfyGQLGetVariantImage.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/GraphQL/Codeunits/ShpfyGQLGetVariantImage.Codeunit.al
@@ -1,0 +1,32 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+
+namespace Microsoft.Integration.Shopify;
+
+/// <summary>
+/// Codeunit Shpfy GQL GetVariantImage (ID 30404) implements Interface Shpfy IGraphQL.
+/// </summary>
+codeunit 30404 "Shpfy GQL GetVariantImage" implements "Shpfy IGraphQL"
+{
+    Access = Internal;
+
+    /// <summary>
+    /// GetGraphQL.
+    /// </summary>
+    /// <returns>Return value of type Text.</returns>
+    internal procedure GetGraphQL(): Text
+    begin
+        exit('{"query":"{ productVariant(id: \"gid://shopify/ProductVariant/{{VariantId}}\") { media(first:1) { edges {node { id }}}}}"}');
+    end;
+
+    /// <summary>
+    /// GetExpectedCost.
+    /// </summary>
+    /// <returns>Return value of type Integer.</returns>
+    internal procedure GetExpectedCost(): Integer
+    begin
+        exit(4);
+    end;
+}

--- a/src/Apps/W1/Shopify/App/src/GraphQL/Enums/ShpfyGraphQLType.Enum.al
+++ b/src/Apps/W1/Shopify/App/src/GraphQL/Enums/ShpfyGraphQLType.Enum.al
@@ -645,4 +645,14 @@ enum 30111 "Shpfy GraphQL Type" implements "Shpfy IGraphQL"
         Caption = 'Get Next Staff Members';
         Implementation = "Shpfy IGraphQL" = "Shpfy GQL NextStaffMembers";
     }
+    value(129; GetVariantImage)
+    {
+        Caption = 'Get Variant Image';
+        Implementation = "Shpfy IGraphQL" = "Shpfy GQL GetVariantImage";
+    }
+    value(130; AddVariantImage)
+    {
+        Caption = 'Add Variant Image';
+        Implementation = "Shpfy IGraphQL" = "Shpfy GQL AddVariantImage";
+    }
 }

--- a/src/Apps/W1/Shopify/App/src/Helpers/Codeunits/ShpfyHash.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/Helpers/Codeunits/ShpfyHash.Codeunit.al
@@ -92,4 +92,21 @@ codeunit 30156 "Shpfy Hash"
                 exit(CalcHash(TenantMedia));
         end;
     end;
+
+    /// <summary> 
+    /// Calc Item Variant Image Hash.
+    /// </summary>
+    /// <param name="ItemVariant">Parameter of type Record "Item Variant".</param>
+    /// <returns>Return value of type Integer.</returns>
+    internal procedure CalcItemVariantImageHash(ItemVariant: Record "Item Variant"): Integer
+    var
+        TenantMedia: Record "Tenant Media";
+        MediaId: Guid;
+    begin
+        if ItemVariant.Picture.Count > 0 then begin
+            MediaId := ItemVariant.Picture.Item(1);
+            if TenantMedia.Get(MediaId) then
+                exit(this.CalcHash(TenantMedia));
+        end;
+    end;
 }

--- a/src/Apps/W1/Shopify/App/src/Products/Codeunits/ShpfyProductEvents.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/Products/Codeunits/ShpfyProductEvents.Codeunit.al
@@ -386,6 +386,17 @@ codeunit 30177 "Shpfy Product Events"
     end;
 
     /// <summary> 
+    /// Raised After Modify Item Variant Picture.
+    /// </summary>
+    /// <param name="ItemVariant">Parameter of type Record "Item Variant".</param>
+    /// <param name="ImageUrl">Parameter of type Text.</param>
+    /// <param name="InStream">Parameter of type InStream.</param>
+    [IntegrationEvent(false, false)]
+    internal procedure OnAfterUpdateItemVariantPicture(var ItemVariant: Record "Item Variant"; ImageUrl: Text; InStream: InStream)
+    begin
+    end;
+
+    /// <summary> 
     /// Raised After Shopify Product fields are filled from Business Central Item. These fields are sent to Shopify when creating or updating a product.
     /// </summary>
     /// <param name="Item">Parameter of type Record Item.</param>

--- a/src/Apps/W1/Shopify/App/src/Products/Codeunits/ShpfyUpdatePictureEntity.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/Products/Codeunits/ShpfyUpdatePictureEntity.Codeunit.al
@@ -1,0 +1,29 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+
+namespace Microsoft.Integration.Shopify;
+
+using Microsoft.Integration.Entity;
+using Microsoft.Inventory.Item;
+
+/// <summary>
+/// Codeunit Shpfy Update Picture Entity (ID 30402).
+/// </summary>
+codeunit 30402 "Shpfy Update Picture Entity"
+{
+    [EventSubscriber(ObjectType::Table, Database::"Picture Entity", OnGetDefaultMediaDescriptionElseCase, '', false, false)]
+    local procedure OnGetDefaultMediaDescriptionElseCase(ParentRecordRef: RecordRef; var MediaDescription: Text; var IsHandled: Boolean)
+    var
+        ItemVariant: Record "Item Variant";
+        PictureEntity: Record "Picture Entity";
+        MediaExtensionWithNumFullNameTxt: Label '%1 %2 %3.%4', Locked = true;
+    begin
+        if ParentRecordRef.Number = Database::"Item Variant" then begin
+            ParentRecordRef.SetTable(ItemVariant);
+            MediaDescription := StrSubstNo(MediaExtensionWithNumFullNameTxt, ItemVariant."Item No.", ItemVariant.Code, ItemVariant.Description, PictureEntity.GetDefaultExtension());
+            IsHandled := true;
+        end;
+    end;
+}

--- a/src/Apps/W1/Shopify/App/src/Products/Page Extensions/ShpfyItemVariantCard.PageExt.al
+++ b/src/Apps/W1/Shopify/App/src/Products/Page Extensions/ShpfyItemVariantCard.PageExt.al
@@ -1,0 +1,28 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+
+namespace Microsoft.Integration.Shopify;
+
+using Microsoft.Inventory.Item;
+
+/// <summary>
+/// PageExtension Shpfy Item Variant Card (ID 30126) extends Page Item Variant
+/// </summary>
+pageextension 30126 "Shpfy Item Variant Card" extends "Item Variant Card"
+{
+    layout
+    {
+        addlast(factboxes)
+        {
+            part(ItemVariantPicture; "Shpfy Item Variant Picture")
+            {
+                ApplicationArea = All;
+                Caption = 'Picture';
+                SubPageLink = "Item No." = field("Item No."),
+                              Code = field(Code);
+            }
+        }
+    }
+}

--- a/src/Apps/W1/Shopify/App/src/Products/Pages/ShpfyItemVariantPicture.Page.al
+++ b/src/Apps/W1/Shopify/App/src/Products/Pages/ShpfyItemVariantPicture.Page.al
@@ -1,0 +1,238 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+
+namespace Microsoft.Integration.Shopify;
+
+using Microsoft.Integration.Entity;
+using Microsoft.Inventory.Item;
+using System.Device;
+using System.IO;
+using System.Text;
+
+/// <summary>
+/// Page Shpfy Item Variant Picture (ID 30173).
+/// </summary>
+page 30173 "Shpfy Item Variant Picture"
+{
+    Caption = 'Item Variant Picture';
+    DeleteAllowed = false;
+    InsertAllowed = false;
+    LinksAllowed = false;
+    PageType = CardPart;
+    SourceTable = "Item Variant";
+
+    layout
+    {
+        area(content)
+        {
+            field(Picture; Rec.Picture)
+            {
+                ApplicationArea = Basic, Suite;
+                ShowCaption = false;
+            }
+        }
+    }
+
+    actions
+    {
+        area(processing)
+        {
+            action(TakePicture)
+            {
+                ApplicationArea = All;
+                Caption = 'Take';
+                Image = Camera;
+                ToolTip = 'Activate the camera on the device.';
+                Visible = this.CameraAvailable and (this.HideActions = false);
+
+                trigger OnAction()
+                begin
+                    this.TakeNewPicture();
+                end;
+            }
+            action(ImportPicture)
+            {
+                ApplicationArea = All;
+                Caption = 'Import';
+                Image = Import;
+                ToolTip = 'Import a picture file.';
+                Visible = this.HideActions = false;
+
+                trigger OnAction()
+                begin
+                    this.ImportFromDevice();
+                end;
+            }
+            action(ExportFile)
+            {
+                ApplicationArea = All;
+                Caption = 'Export';
+                Enabled = this.DeleteExportEnabled;
+                Image = Export;
+                ToolTip = 'Export the picture to a file.';
+                Visible = this.HideActions = false;
+
+                trigger OnAction()
+                var
+                    DummyPictureEntity: Record "Picture Entity";
+                    FileManagement: Codeunit "File Management";
+                    StringConversionManager: Codeunit StringConversionManagement;
+                    ToFile: Text;
+                    ConvertedCodeType: Text;
+                    ExportPath: Text;
+                begin
+                    Rec.TestField("Item No.");
+                    Rec.TestField("Code");
+                    Rec.TestField(Description);
+                    ConvertedCodeType := Format(Rec."Code");
+                    ToFile := DummyPictureEntity.GetDefaultMediaDescription(Rec); 
+                    ConvertedCodeType := StringConversionManager.RemoveNonAlphaNumericCharacters(ConvertedCodeType);
+                    ExportPath := TemporaryPath + ConvertedCodeType + Format(Rec.Picture.MediaId);
+                    Rec.Picture.ExportFile(ExportPath + '.' + DummyPictureEntity.GetDefaultExtension());
+
+                    FileManagement.ExportImage(ExportPath, ToFile);
+                end;
+            }
+            action(DeletePicture)
+            {
+                ApplicationArea = All;
+                Caption = 'Delete';
+                Enabled = this.DeleteExportEnabled;
+                Image = Delete;
+                ToolTip = 'Delete the record.';
+                Visible = this.HideActions = false;
+
+                trigger OnAction()
+                begin
+                    this.DeleteItemPicture();
+                end;
+            }
+        }
+    }
+
+    trigger OnAfterGetCurrRecord()
+    begin
+        this.SetEditableOnPictureActions();
+    end;
+
+    trigger OnOpenPage()
+    begin
+        this.CameraAvailable := this.Camera.IsAvailable();
+    end;
+
+    var
+        Camera: Codeunit Camera;
+        CameraAvailable: Boolean;
+        OverrideImageQst: Label 'The existing picture will be replaced. Do you want to continue?';
+        DeleteImageQst: Label 'Are you sure you want to delete the picture?';
+        SelectPictureTxt: Label 'Select a picture to upload';
+        DeleteExportEnabled: Boolean;
+        HideActions: Boolean;
+        MustSpecifyDescriptionErr: Label 'You must add a description to the item variant before you can import a picture.';
+        MimeTypeTok: Label 'image/jpeg', Locked = true;
+
+    procedure TakeNewPicture()
+    begin
+        Rec.Find();
+        Rec.TestField("Item No.");
+        Rec.TestField("Code");
+        Rec.TestField(Description);
+
+        this.OnAfterTakeNewPicture(Rec, this.DoTakeNewPicture());
+    end;
+
+    [Scope('OnPrem')]
+    procedure ImportFromDevice()
+    var
+        FileManagement: Codeunit "File Management";
+        FileName: Text;
+        ClientFileName: Text;
+    begin
+        Rec.Find();
+        Rec.TestField("Item No.");
+        Rec.TestField("Code");
+        if Rec.Description = '' then
+            Error(this.MustSpecifyDescriptionErr);
+
+        if Rec.Picture.Count > 0 then
+            if not Confirm(this.OverrideImageQst) then
+                Error('');
+
+        ClientFileName := '';
+        FileName := FileManagement.UploadFile(this.SelectPictureTxt, ClientFileName);
+        if FileName = '' then
+            Error('');
+
+        Clear(Rec.Picture);
+        Rec.Picture.ImportFile(FileName, ClientFileName);
+        Rec.Modify(true);
+        this.OnImportFromDeviceOnAfterModify(Rec);
+
+        if FileManagement.DeleteServerFile(FileName) then;
+    end;
+
+    local procedure DoTakeNewPicture(): Boolean
+    var
+        PictureInstream: InStream;
+        PictureDescription: Text;
+    begin
+        if Rec.Picture.Count() > 0 then
+            if not Confirm(this.OverrideImageQst) then
+                exit(false);
+
+        if this.Camera.GetPicture(PictureInstream, PictureDescription) then begin
+            Clear(Rec.Picture);
+            Rec.Picture.ImportStream(PictureInstream, PictureDescription, this.MimeTypeTok);
+            Rec.Modify(true);
+            exit(true);
+        end;
+
+        exit(false);
+    end;
+
+    local procedure SetEditableOnPictureActions()
+    begin
+        this.DeleteExportEnabled := Rec.Picture.Count <> 0;
+    end;
+
+    procedure IsCameraAvailable(): Boolean
+    begin
+        exit(this.Camera.IsAvailable());
+    end;
+
+    procedure SetHideActions()
+    begin
+        this.HideActions := true;
+    end;
+
+    procedure DeleteItemPicture()
+    begin
+        Rec.TestField("Item No.");
+        Rec.TestField("Code");
+
+        if not Confirm(this.DeleteImageQst) then
+            exit;
+
+        Clear(Rec.Picture);
+        Rec.Modify(true);
+
+        this.OnAfterDeleteItemPicture(Rec);
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnAfterDeleteItemPicture(var ItemVariant: Record "Item Variant")
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnAfterTakeNewPicture(var ItemVariant: Record "Item Variant"; IsPictureAdded: Boolean)
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnImportFromDeviceOnAfterModify(var ItemVariant: Record "Item Variant")
+    begin
+    end;
+}

--- a/src/Apps/W1/Shopify/App/src/Products/Table Extensions/ShpfyItemVariant.TableExt.al
+++ b/src/Apps/W1/Shopify/App/src/Products/Table Extensions/ShpfyItemVariant.TableExt.al
@@ -1,0 +1,28 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+
+namespace Microsoft.Integration.Shopify;
+
+using Microsoft.Inventory.Item;
+
+/// <summary>
+/// TableExtension Shpfy Item Variant (ID 30112) extends Record Item Variant.
+/// </summary>
+tableextension 30112 "Shpfy Item Variant" extends "Item Variant"
+{
+    fields
+    {
+        field(30100; Picture; MediaSet)
+        {
+            Caption = 'Picture';
+            ToolTip = 'Specifies the picture that has been inserted for the item variant.';
+            DataClassification = CustomerContent;
+        }
+    }
+    fieldgroups
+    {
+        addlast(Brick; Code, Description, Picture) { }
+    }
+}


### PR DESCRIPTION
### Added support for Item Variant picture
- New Item Variant table extension with added Picture field
- New Item Variant Picture page (similar to Item Picture page from base app) 
- New Item Variant Card page extension for showing created Item Variant Picture 
- Added event subscriber for getting media description for Item Variant

**Item Variant Synchronization**
- New GQL query codeunit to get variant image id from shopify 
- New GQL query codeunit to add variant image in shopify 
- New GQL Query Enum values
- Modified Shpfy Product API codeunit to be able to reuse functionality for product variants
- In Shpfy Variant API codeunit added procedure to check if variant has image in shopify 
- In Shpfy Variant API codeunit added procedure for setting new image for variant (export to shopify)
- Added Shpfy Variant Image Export codeunit for handling export to shopify functionality, similar to Shpfy Product Image Export 
- Modified Shpfy Sync Product Image codeunit to handle variants images import to BC, changed ImportImages() procedure so that Product image cannot be taken from variant images

### Missing:
- Updating existing images in shopify with new ones from BC (also handle bulk exports) 
- Automated tests

<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->

#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes #
